### PR TITLE
Show active players in navbar and stale on hover

### DIFF
--- a/packages/webapp/src/components/PlayersConnected/PlayersConnected.module.css
+++ b/packages/webapp/src/components/PlayersConnected/PlayersConnected.module.css
@@ -1,2 +1,19 @@
 .Connected {
+    display: flex;
+    flex-direction: row;
+    transition: all 1s ease-in-out;
+}
+
+.Connected:hover {
+    cursor: pointer;
+}
+
+.Stale {
+    margin-left: 0.2rem;
+    color: #5603AD;
+    display: none;
+}
+
+.Connected:hover>.Stale {
+    display: block;
 }

--- a/packages/webapp/src/components/PlayersConnected/PlayersConnected.module.css
+++ b/packages/webapp/src/components/PlayersConnected/PlayersConnected.module.css
@@ -1,7 +1,6 @@
 .Connected {
     display: flex;
     flex-direction: row;
-    transition: all 1s ease-in-out;
 }
 
 .Connected:hover {
@@ -9,11 +8,9 @@
 }
 
 .Stale {
-    margin-left: 0.2rem;
-    color: #5603AD;
-    display: none;
+    margin-left: 0.25rem;
 }
 
-.Connected:hover>.Stale {
-    display: block;
+.StaleHidden {
+    display: none;
 }

--- a/packages/webapp/src/components/PlayersConnected/index.tsx
+++ b/packages/webapp/src/components/PlayersConnected/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useAppSelector } from "../../hooks";
 import classes from './PlayersConnected.module.css';
 
@@ -7,14 +8,18 @@ const PlayersConnected: React.FC<{}> = props => {
   const activeVoters = useAppSelector(state => state.vote.activeVoters);
   const voteConnected = useAppSelector(state => state.vote.connected);
 
+  const [showStalePlayers, setShowStalePlayers] = useState(false);
+
   if (!activeAuction && voteConnected) {
     return (
-      <div className={classes.Connected}>
+      <div 
+        onClick={() => setShowStalePlayers(!showStalePlayers)}
+        className={classes.Connected}>
         <span>
           Active Players: {activeVoters}
         </span>
-        <span className={classes.Stale}>
-          Stale: {numConnections - activeVoters}
+        <span className={showStalePlayers ? classes.Stale : classes.StaleHidden}>
+          · Stale: {numConnections - activeVoters}
         </span>
       </div>
     );

--- a/packages/webapp/src/components/PlayersConnected/index.tsx
+++ b/packages/webapp/src/components/PlayersConnected/index.tsx
@@ -4,13 +4,19 @@ import classes from './PlayersConnected.module.css';
 const PlayersConnected: React.FC<{}> = props => {
   const activeAuction = useAppSelector(state => state.auction.activeAuction);
   const numConnections = useAppSelector(state => state.vote.numConnections);
+  const activeVoters = useAppSelector(state => state.vote.activeVoters);
   const voteConnected = useAppSelector(state => state.vote.connected);
 
   if (!activeAuction && voteConnected) {
     return (
-      <span className={classes.Connected}>
-        Players: {numConnections}
-      </span>
+      <div className={classes.Connected}>
+        <span>
+          Active Players: {activeVoters}
+        </span>
+        <span className={classes.Stale}>
+          Stale: {numConnections - activeVoters}
+        </span>
+      </div>
     );
   } else {
     return <></>

--- a/packages/webapp/src/middleware/voteWebsocket.js
+++ b/packages/webapp/src/middleware/voteWebsocket.js
@@ -6,7 +6,8 @@ import {
   setNumConnections,
   setScore,
   incrementCount,
-  triggerSettlement
+  triggerSettlement,
+  setActiveVoters
 } from '../state/slices/vote';
 
 
@@ -56,7 +57,7 @@ const voteWebsocketMiddleware = () => {
         store.dispatch(setNumConnections(data.connections));
       }
       if ('activeVoters' in data) {
-        store.dispatch(setNumConnections(data.connections));
+        store.dispatch(setActiveVoters(data.activeVoters));
       }
     } catch(err) {
       console.error('Erroring parsing FOMO websocket message');

--- a/packages/webapp/src/middleware/voteWebsocket.js
+++ b/packages/webapp/src/middleware/voteWebsocket.js
@@ -55,6 +55,9 @@ const voteWebsocketMiddleware = () => {
       if('connections' in data) {
         store.dispatch(setNumConnections(data.connections));
       }
+      if ('activeVoters' in data) {
+        store.dispatch(setNumConnections(data.connections));
+      }
     } catch(err) {
       console.error('Erroring parsing FOMO websocket message');
       console.error(err);

--- a/packages/webapp/src/state/slices/vote.ts
+++ b/packages/webapp/src/state/slices/vote.ts
@@ -21,7 +21,7 @@ interface VoteState {
 const initialState: VoteState = {
   connected: false,
   numConnections: 1,
-  activeVoters: 1,
+  activeVoters: 0,
   currentVote: undefined,
   voteCounts: {voteLike: 0, voteShrug: 0, voteDislike: 0}, // TODO: Make this programmatic
   attemptedSettle: false,
@@ -43,7 +43,7 @@ export const voteSlice = createSlice({
     setNumConnections: (state, action: PayloadAction<number | undefined>) => {
       state.numConnections = action.payload === undefined ? 1 : action.payload;
     },
-    setActiveVotes: (state, action: PayloadAction<number | undefined>) => {
+    setActiveVoters: (state, action: PayloadAction<number | undefined>) => {
       state.activeVoters = action.payload === undefined ? 1 : action.payload;
     },
     setCurrentVote: (state, action: PayloadAction<VOTE_OPTIONS | undefined | null>) => {
@@ -75,7 +75,7 @@ export const voteSlice = createSlice({
 export const {
   setConnected,
   setNumConnections,
-  setActiveVotes,
+  setActiveVoters,
   setCurrentVote,
   setScore,
   incrementCount,

--- a/packages/webapp/src/state/slices/vote.ts
+++ b/packages/webapp/src/state/slices/vote.ts
@@ -9,6 +9,7 @@ export enum VOTE_OPTIONS {
 interface VoteState {
   connected: boolean;
   numConnections: number;
+  activeVoters: number;
   currentVote?: VOTE_OPTIONS;
   voteCounts: Record<VOTE_OPTIONS, number>;
   attemptedSettle: boolean;
@@ -20,6 +21,7 @@ interface VoteState {
 const initialState: VoteState = {
   connected: false,
   numConnections: 1,
+  activeVoters: 1,
   currentVote: undefined,
   voteCounts: {voteLike: 0, voteShrug: 0, voteDislike: 0}, // TODO: Make this programmatic
   attemptedSettle: false,
@@ -41,6 +43,9 @@ export const voteSlice = createSlice({
     setNumConnections: (state, action: PayloadAction<number | undefined>) => {
       state.numConnections = action.payload === undefined ? 1 : action.payload;
     },
+    setActiveVotes: (state, action: PayloadAction<number | undefined>) => {
+      state.activeVoters = action.payload === undefined ? 1 : action.payload;
+    },
     setCurrentVote: (state, action: PayloadAction<VOTE_OPTIONS | undefined | null>) => {
       state.currentVote = action.payload === null ? undefined : action.payload;
     },
@@ -59,6 +64,7 @@ export const voteSlice = createSlice({
     resetVotes: (state) => ({
       ...initialState,
       numConnections: state.numConnections,
+      activeVotes: state.activeVoters,
       connected: state.connected,
       // If user lodged a vote, reset missed vote counter, otherwise increment it
       missedVotes: (!state.currentVote ? state.missedVotes+1 : initialState.missedVotes)
@@ -69,6 +75,7 @@ export const voteSlice = createSlice({
 export const {
   setConnected,
   setNumConnections,
+  setActiveVotes,
   setCurrentVote,
   setScore,
   incrementCount,


### PR DESCRIPTION
Show active players count in the navbar instead of the total amount of players(connected clients). And show the number of stale players on hover over the "Active Players: {N}" element.

Rationale:
People get confused seeing many players in the navbar that don't match the number of votes on the buttons. This happens in the case of big number of inactive(stale) players.