### PR TITLE
Fix: Single Noun image on mobile should be 500px

### DIFF
--- a/packages/webapp/src/components/Noun/Noun.module.css
+++ b/packages/webapp/src/components/Noun/Noun.module.css
@@ -1,3 +1,4 @@
+/* Double Noun */
 .nounsWrapper {
     border: 1px solid #000000;
     margin:  0.5em 0 0.75em 0;
@@ -20,13 +21,21 @@
     border-bottom:  1px solid #000;
 }
 
+/* Single Noun */
+.nounWrapper .img {
+    max-width: 500px;
+}
+
+/* Double Noun */
+.nounsWrapper .img {
+    max-width: 200px;
+}
 
 .img {
     image-rendering: pixelated;
     image-rendering: -moz-crisp-edges;
     width: 100%;
     height: 100%;
-    max-width: 200px;
 }
 
 .noun-1 .img {
@@ -50,6 +59,7 @@
 }
 
 @media only screen and (min-width: 768px) {
+    /* Double Noun */
     .nounsWrapper {
         display: flex;
         margin: 1.5em 0;
@@ -68,7 +78,8 @@
       font-size:  2em;
     }
 
-    .img {
+    /* Single & Double Noun */
+    .nounWrapper .img, .nounsWrapper .img, {
         max-width: 500px;
     }
 
@@ -82,9 +93,9 @@
 }
 
 @media only screen and (min-width: 1025px) {
-    .img {
-        width:  500px;
-        max-width: 500px;
+    /* Single & Double Noun */
+    .nounWrapper .img, .nounsWrapper .img, {
+        width: 500px;
     }
 
     .nounId {


### PR DESCRIPTION
This fixes a regression from #7 which reduced the single view Noun image to 200px. Previously it was 500px.

**Before Fix**
![image](https://user-images.githubusercontent.com/83411264/170743712-eb283aaa-189b-45bf-b3f5-aea12fb0a5d6.png)

**After Fix**
![image](https://user-images.githubusercontent.com/83411264/170743780-8e458539-a89e-4359-a49c-591c4386312e.png)
