### PR TITLE
Prevent voting on incorrect Noun when blocks are produced quickly

### DIFF
--- a/packages/webapp/src/components/VoteBar/index.tsx
+++ b/packages/webapp/src/components/VoteBar/index.tsx
@@ -19,7 +19,7 @@ const VoteBar:React.FC<{}> = (props) => {
   useEffect( () => {
     const timerId = setTimeout(dispatch, 500, setVotingBlockHash(blockhash));
     return () => clearTimeout(timerId);
-  }, [blockhash])
+  }, [blockhash, dispatch])
 
   const openSocket = () => {
     if (!voteSocketConnected) {

--- a/packages/webapp/src/components/VoteBar/index.tsx
+++ b/packages/webapp/src/components/VoteBar/index.tsx
@@ -1,5 +1,6 @@
+import React, { useEffect } from "react";
 import VoteButton from '../VoteButton';
-import { VOTE_OPTIONS } from '../../state/slices/vote';
+import { VOTE_OPTIONS, setVotingBlockHash } from '../../state/slices/vote';
 import classes from './VoteBar.module.css';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { openVoteSocket } from '../../middleware/voteWebsocket';
@@ -12,6 +13,13 @@ const VoteBar:React.FC<{}> = (props) => {
   const voteSocketConnected = useAppSelector(state => state.vote.connected);
   const ethereumSocketConnected = useAppSelector(state => state.block.connected);
   const votingActive = useAppSelector(state => state.vote.votingActive);
+  const blockhash = useAppSelector(state => state.block.blockHash);
+
+  // Approves a specific blockhash for voting after a period of time. This prevents the user from voting on a Noun by mistake as a new block is received.
+  useEffect( () => {
+    const timerId = setTimeout(dispatch, 500, setVotingBlockHash(blockhash));
+    return () => clearTimeout(timerId);
+  }, [blockhash])
 
   const openSocket = () => {
     if (!voteSocketConnected) {

--- a/packages/webapp/src/components/VoteButton/index.tsx
+++ b/packages/webapp/src/components/VoteButton/index.tsx
@@ -20,9 +20,10 @@ const VoteButton: React.FC<{voteType: VOTE_OPTIONS}> = props => {
   const activeAuction = useAppSelector(state => state.auction.activeAuction);
   const currentVote = useAppSelector(state => state.vote.currentVote);
   const wsConnected = useAppSelector(state => state.vote.connected);
-  const hash = useAppSelector(state => state.block.blockHash);
+  const blockHash = useAppSelector(state => state.block.blockHash);
   const nextNounId = useAppSelector(state => state.noun.nextNounId);
   const voteCounts = useAppSelector(state => state.vote.voteCounts);
+  const votingBlockHash = useAppSelector(state => state.vote.votingBlockHash);
 
   const votingActive = useAppSelector(state => state.vote.votingActive);
 
@@ -33,12 +34,14 @@ const VoteButton: React.FC<{voteType: VOTE_OPTIONS}> = props => {
     if (currentVote || !wsConnected) return;
     
     dispatch(setCurrentVote(voteType));
-    dispatch(sendVote({"nounId": nextNounId, "blockhash": hash, "vote": voteType}));
+    dispatch(sendVote({"nounId": nextNounId, "blockhash": blockHash, "vote": voteType}));
   }
+
+  const disabled = voteNotSelected || (!votingActive || activeAuction) || blockHash !== votingBlockHash
 
   return (
       <button className={currentVote === voteType ? clsx(classes.voteButton, classes.selected) : classes.voteButton} onClick={changeVote}
-      disabled={voteNotSelected || (!votingActive || activeAuction)}>
+      disabled={disabled}>
         <span className={classes.voteEmojiText}> {voteToEmoji[voteType]} </span>
         <span className={classes.voteText}> {voteCounts[voteType]} </span>
       </button>

--- a/packages/webapp/src/state/slices/vote.ts
+++ b/packages/webapp/src/state/slices/vote.ts
@@ -14,6 +14,7 @@ interface VoteState {
   voteCounts: Record<VOTE_OPTIONS, number>;
   attemptedSettle: boolean;
   votingActive: boolean;
+  votingBlockHash?: string;
   score: number;
   missedVotes: number;
 }
@@ -26,6 +27,7 @@ const initialState: VoteState = {
   voteCounts: {voteLike: 0, voteShrug: 0, voteDislike: 0}, // TODO: Make this programmatic
   attemptedSettle: false,
   votingActive: true,
+  votingBlockHash: undefined,
   score: 0,
   missedVotes: 0
 };
@@ -68,7 +70,10 @@ export const voteSlice = createSlice({
       connected: state.connected,
       // If user lodged a vote, reset missed vote counter, otherwise increment it
       missedVotes: (!state.currentVote ? state.missedVotes+1 : initialState.missedVotes)
-    })
+    }),
+    setVotingBlockHash: (state, action: PayloadAction<string | undefined >) => {
+      state.votingBlockHash = action.payload;
+    },
   },
 });
 
@@ -81,7 +86,8 @@ export const {
   incrementCount,
   triggerSettlement,
   endVoting,
-  resetVotes
+  resetVotes,
+  setVotingBlockHash
 } = voteSlice.actions;
 
 export default voteSlice.reducer;


### PR DESCRIPTION
Sometimes a block is received just as a user is tapping/clicking a vote button causing them to vote on a Noun incorrectly. 

This change "approves" a block hash 500ms after it has been received and disables the vote button until then. The result is that if a user tap/clicks within a 500ms window of a new Noun, their vote won't be registered and they won't vote incorrectly.