### PR TITLE
[#8 Alt]: Mobile 500px Fix & Slight Simplification

### DIFF
--- a/packages/webapp/src/components/Noun/Noun.module.css
+++ b/packages/webapp/src/components/Noun/Noun.module.css
@@ -1,95 +1,45 @@
-.nounsWrapper {
-    border: 1px solid #000000;
-    margin:  0.5em 0 0.75em 0;
-    box-shadow: 2px 5px 5px 2px rgba(0, 0, 0, 0.25);
-    border-radius: 20px;
-
-}
-
-.nounWrapper .nounId {
-    display: none;
-}
-
-
-.imgWrapper{
-    z-index: 0;
-    position: relative;
-}
-
-.noun-1 {
-    border-bottom:  1px solid #000;
-}
-
-
 .img {
     image-rendering: pixelated;
     image-rendering: -moz-crisp-edges;
     width: 100%;
     height: 100%;
+}
+
+.imgWrapper {
+    display: flex;
+    justify-content: center;
+}
+
+.multinounWrapper {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    
+    border: 1px solid #000;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 2px 5px 5px 2px rgba(0, 0, 0, 0.25);
+
+    margin: 1em;
+}
+
+.multinounWrapper .img {
     max-width: 200px;
 }
 
-.noun-1 .img {
-    border-radius: 20px 20px 0 0;
-}
-
-.noun-2 .img {
-    border-radius: 0 0 20px 20px;
-}
-
-.nounId {
-    position: absolute;
-    top: 0em;
-    left: 0.5em;
-    font-size:  1.5em;
-    font-family: 'Londrina Solid';
-}
-
-.nounId {
-    display: none;
+@media only screen and (min-width: 500px) {
+    .imgWrapper .img {
+        width: 500px;
+        max-width: 100%;
+    }
 }
 
 @media only screen and (min-width: 768px) {
-    .nounsWrapper {
-        display: flex;
-        margin: 1.5em 0;
+    .multinounWrapper .img {
+        width: 500px;
+        max-width: 100%;
     }
-
-    .imgWrapper{
-        position: relative;
-    }
-
-    .noun-1 {
-        border-bottom:  0;
-        border-right:  1px solid #000;
-    }
-
-    .nounId {
-      font-size:  2em;
-    }
-
-    .img {
-        max-width: 500px;
-    }
-
-    .noun-1 .img {
-        border-radius: 20px 0 0 20px;
-    }
-
-    .noun-2 .img {
-        border-radius: 0 20px 20px 0;
-    }
-}
-
-@media only screen and (min-width: 1025px) {
-    .img {
-        width:  500px;
-        max-width: 500px;
-    }
-
-    .nounId {
-      top:  auto;
-      bottom:  0;
-      font-size:  3em;
+    .multinounWrapper {
+        flex-direction: row;
     }
 }

--- a/packages/webapp/src/components/Noun/index.tsx
+++ b/packages/webapp/src/components/Noun/index.tsx
@@ -49,20 +49,14 @@ const Noun: React.FC = props => {
 
   useEffect(()=>{
     // When there's only 1 Noun, change the page background to match
-    if (nounImageData.length > 1) return
+    if (nounImageData.length > 1) return;
     dispatch(setActiveBackground(nounImageData[0].seed.background === 0));
   },[dispatch, nounImageData])
 
 
   const Imgs = nounImageData.map( ({src, alt}, i) => {
-    let imgWrapper = [classes.imgWrapper]
-
-
-    if (nounImageData.length > 1) imgWrapper.push(classes[`noun-${i+1}`])
-
     return (
-      <div className={`${imgWrapper.join(' ')}`}>
-        <div className={classes.nounId}><span>Noun </span>{nextNounId+i}</div>
+      <div>
         <img
           className={classes.img}
           src={src}
@@ -72,13 +66,8 @@ const Noun: React.FC = props => {
       )
   })
 
-  let wrapperClass = classes.nounWrapper
-  if (nounImageData.length > 1) {
-    wrapperClass = classes.nounsWrapper
-  }
-
   return (
-    <div className={wrapperClass}>
+    <div className={Imgs.length > 1 ? classes.multinounWrapper : classes.imgWrapper}>
       {Imgs}
     </div>
   );

--- a/packages/webapp/src/components/VoteBar/VoteBar.module.css
+++ b/packages/webapp/src/components/VoteBar/VoteBar.module.css
@@ -2,7 +2,7 @@
     display: flex;
     justify-content: space-evenly;
     gap: 10px;
-    width: 30%;
+    width: 80%;
     min-height: 80px;
     min-width: 320px;
     padding: .8em;
@@ -25,4 +25,10 @@
     font-size: 1.5em;
     font-weight: bold;
     cursor: pointer;
+}
+
+@media only screen and (min-width: 600px) {
+    .VoteBar {
+        width: 500px;
+    }
 }

--- a/packages/webapp/src/components/VoteBar/VoteBar.module.css
+++ b/packages/webapp/src/components/VoteBar/VoteBar.module.css
@@ -1,32 +1,3 @@
-/*.VoteBar {
-    display: flex;
-    justify-content: space-evenly;
-    gap: 10px;
-    width: 30%;
-    min-height: 80px;
-    min-width: 320px;
-    padding: .8em;
-    border-radius: 20px;
-    border: 1px solid #000000;
-    box-shadow: 2px 5px 5px 2px rgba(0, 0, 0, 0.25);
-    margin-bottom: 20px;
-}
-
-.VoteBarOverlay {
-    background-color: white;
-    opacity: 0.5;
-}
-
-.reconnect {
-    width: 100%;
-    margin: auto;
-    text-align: center;
-    font-family: Roboto Mono;
-    font-size: 1.5em;
-    font-weight: bold;
-    cursor: pointer;
-}*/
-
 .VoteBar {
     display: flex;
     justify-content: space-evenly;


### PR DESCRIPTION
This is an alternate fix on the mobile fix for PR #7 with an alternate approach to display the two Nouns. This loses the middle border between the Nouns, but it reduces some of the TS and CSS code and may be a bit more flexible (responsive) across different widths.

<img width="197" alt="image" src="https://user-images.githubusercontent.com/84751016/171779669-4baf3e08-3743-44c1-9e47-99ef4f1d20f6.png"> <img width="196" alt="image" src="https://user-images.githubusercontent.com/84751016/171779707-9de53df1-3436-4286-a1af-96cf0e21ea6d.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/84751016/171779771-6c632dcf-011b-471e-bd50-e30bc5e567f4.png"> <img width="350" alt="image" src="https://user-images.githubusercontent.com/84751016/171779819-d53ed546-657e-416d-b07a-66c54bffaf5d.png">