### PR TITLE
Hide the progress bar while the auction is active

### DIFF
--- a/packages/webapp/src/components/VoteProgressBar/VoteProgressBar.module.css
+++ b/packages/webapp/src/components/VoteProgressBar/VoteProgressBar.module.css
@@ -1,9 +1,9 @@
 .Wrapper {
     width: 100%;
-    display: flex;
     justify-content: center;
     padding-bottom: 5px;
     z-index: 10;
+    display: none;
 }
 
 .BarOutline {

--- a/packages/webapp/src/components/VoteProgressBar/index.tsx
+++ b/packages/webapp/src/components/VoteProgressBar/index.tsx
@@ -10,20 +10,21 @@ const VoteProgressBar: React.FC<{}> = props => {
         const min = 5;
         score = score < min ? min : score;
         const max = 100;
-        score = score > max ? max : score; 
+        score = score > max ? max : score;
     }
     const barStyle = {
         width: `${score}%`,
         transition: 'width .15s ease-out'
     };
-    
-    const opacity = activeAuction ? 0.5 : 1;
-    const parentStyle = {
-        opacity: opacity 
+
+    const display = activeAuction === true || activeAuction === undefined ? 'none' : 'flex';
+    const wrapperStyle = {
+        display
     };
+
     return(
-        <div className={classes.Wrapper}>
-            <div className={classes.BarOutline} style={parentStyle}>
+        <div className={classes.Wrapper} style={wrapperStyle}>
+            <div className={classes.BarOutline}>
                 <div className={classes.ProgressBar} style={barStyle}/>
             </div>
         </div>


### PR DESCRIPTION
This PR hides the voting progress bar when voting is not possible during an active Noun auction.

![image](https://user-images.githubusercontent.com/83411264/173088800-db06891b-2e8b-4c76-be91-3bb4c3ac0f7a.png)
