### PR TITLE
Default to double Noun view for 420

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -4,7 +4,7 @@ import { useAppDispatch, useAppSelector } from './hooks';
 
 import { contract as AuctionContract } from './wrappers/nounsAuction';
 import { setAuctionEnd } from './state/slices/auction';
-import { setNextNounId } from './state/slices/noun';
+import { setNextNounId, setDisplaySingleNoun } from './state/slices/noun';
 import { setBlockAttr } from './state/slices/block';
 import { provider } from './config';
 
@@ -46,6 +46,9 @@ function App() {
     dispatch(setNextNounId(nextNounId));
     dispatch(setAuctionEnd(auctionEnd));
     dispatch(setBlockAttr({blocknumber, blockhash}))
+    if (nextNounId === 420) {
+      dispatch(setDisplaySingleNoun(false));
+    }
   }, [dispatch])
 
   useEffect(() => {


### PR DESCRIPTION
For the one-time special occasion of **Noun 420**, this PR defaults to double Noun view. For every other double mint day, the default remains the single Noun view. The Hide/Show toggle remains functional in both circumstances.

![](https://cdn.discordapp.com/attachments/1001875566804344872/1011637818868633733/unknown.png)
