### PR TITLE
Show toasts only for `settleCurrentAndCreateNewAuction` method transactions

### DIFF
--- a/packages/webapp/src/utils/auctionMethods.ts
+++ b/packages/webapp/src/utils/auctionMethods.ts
@@ -1,12 +1,12 @@
 import { contract as AuctionContract } from '../wrappers/nounsAuction';
 
-const settleMethods = ['settleCurrentAndCreateNewAuction', 'settleAuction']
+const settleMethod = 'settleCurrentAndCreateNewAuction'
 const bidMethod = 'createBid'
 
 export const isSettleMethod = (input: string) => {
     try {
         const decodedInput = AuctionContract.interface.parseTransaction({ data: input })
-        return settleMethods.includes(decodedInput.name);
+        return decodedInput.name === settleMethod;
     } catch {
         return false;
     }

--- a/packages/webapp/src/utils/auctionMethods.ts
+++ b/packages/webapp/src/utils/auctionMethods.ts
@@ -3,10 +3,14 @@ import { contract as AuctionContract } from '../wrappers/nounsAuction';
 const settleMethod = 'settleCurrentAndCreateNewAuction'
 const bidMethod = 'createBid'
 
+const decodeMethod = (input: string) => {
+    const decodedInput = AuctionContract.interface.parseTransaction({ data: input })
+    return decodedInput.name
+}
+
 export const isSettleMethod = (input: string) => {
     try {
-        const decodedInput = AuctionContract.interface.parseTransaction({ data: input })
-        return decodedInput.name === settleMethod;
+        return decodeMethod(input) === settleMethod;
     } catch {
         return false;
     }
@@ -14,8 +18,7 @@ export const isSettleMethod = (input: string) => {
 
 export const isBidMethod = (input: string) => {
     try {
-        const decodedInput = AuctionContract.interface.parseTransaction({ data: input })
-        return decodedInput.name === bidMethod;
+        return decodeMethod(input) === bidMethod;
     } catch {
         return false;
     }


### PR DESCRIPTION
As `settleCurrent` method is callable only when the Auction House is paused, there is no reason to listen to these transactions from Fomo's standpoint.

There is also a small refactor on the tx method check functions. ([Link](https://github.com/fomo-nouns/fomo-nouns/pull/20#issuecomment-1249662035) to info on how to test the toasts functionality)