### PR TITLE
Ng mintend noun modal show incorrect noun

### DIFF
--- a/packages/webapp/src/components/Modal/Modal.module.css
+++ b/packages/webapp/src/components/Modal/Modal.module.css
@@ -1,57 +1,58 @@
 .backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    background: rgba(0, 0, 0, 0.75);
-  }
-  
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.75);
+}
+
+.modal {
+  position: fixed;
+  z-index: 100;
+  background-color: white;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 15px;
+  left: calc(50% - 15rem);
+  width: 30rem;
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+.modal h3 {
+  font-size: xx-large;
+  font-weight: bold;
+}
+
+.content {
+  padding: 1rem 1rem .2rem 1rem;
+}
+
+.modal .closeButton {
+  cursor: pointer;
+  position: absolute;
+  top: 1rem;
+  right: 2rem;
+  border: 0 none;
+  background-color: transparent;
+}
+
+.modal button img {
+  width: 1rem;
+  height: auto;
+}
+
+@media (max-width: 992px) {
   .modal {
-    position: fixed;
-    top: 25vh;
-    left: 10%;
-    width: 80%;
-    z-index: 100;
-    background-color: white;
-    padding: 2rem;
-    text-align: center;
-    border-radius: 15px;
-    left: calc(50% - 15rem);
-    width: 30rem;
+    top: auto;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    max-height: 100%;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    transform: translate(0, 0);
   }
-  
-  .modal h3 {
-    font-size: xx-large;
-    font-weight: bold;
-  }
-  
-  .content {
-    padding: 1rem 1rem .2rem 1rem;
-  }
-  
-  .modal .closeButton {
-    cursor: pointer;
-    position: absolute;
-    top: 1rem;
-    right: 2rem;
-    border: 0 none;
-    background-color: transparent;
-  }
-  .modal button img {
-    width: 1rem;
-    height: auto;
-  }
-  
-  @media (max-width: 992px) {
-    .modal {
-      top: auto;
-      left: 0;
-      bottom: 0;
-      width: 100%;
-      max-height: 100%;
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-  }
+}

--- a/packages/webapp/src/components/SettledAuctionModal/index.tsx
+++ b/packages/webapp/src/components/SettledAuctionModal/index.tsx
@@ -13,63 +13,63 @@ const { palette } = ImageData;
 const SettledAuctionModal: React.FC<{}> = props => {
 
   const confettiConfig = {
-      angle: 80,
-      spread: 180,
-      startVelocity: 70,
-      elementCount: 150,
-      dragFriction: 0.12,
-      duration: 9000,
-      stagger: 8,
-      width: "10px",
-      height: "10px",
-      colors: ["#a864fd", "#29cdff", "#8efc62", "#fa5768", "#fdff6a", '#f9b9f2']
+    angle: 80,
+    spread: 180,
+    startVelocity: 70,
+    elementCount: 150,
+    dragFriction: 0.12,
+    duration: 9000,
+    stagger: 8,
+    width: "10px",
+    height: "10px",
+    colors: ["#a864fd", "#29cdff", "#8efc62", "#fa5768", "#fdff6a", '#f9b9f2']
   };
 
   const dispatch = useAppDispatch();
 
   // local state variables
-  const [showConnectModal, setShowConnectModal] = useState(false);
-  const [successfulSettle, setSuccessfulSettle] = useState(false);
+  const [showSettledNounModal, setShowSettledNounModal] = useState(false);
+  const [successfulFomoSettle, setSuccessfulFomoSettle] = useState(false);
   const [localNounId, setLocalNounId] = useState(0);
   const [img, setImg] = useState("");
   const [showConfetti, setConfetti] = useState(false);
   const [shareCopy, setShareCopy] = useState("");
   const [mediaURL, setMediaURL] = useState("");
   const [showTwitter, setShowTwitter] = useState(false);
-  
+
   const prevSettledBlockHash = useAppSelector(state => state.settlement.prevSettledBlockHash);
   const attemptedSettleBlockHash = useAppSelector(state => state.settlement.attemptedSettleBlockHash);
   const nextNounId = useAppSelector(state => state.noun.nextNounId);
 
   const showModalHandler = () => {
-    setShowConnectModal(true);
+    setShowSettledNounModal(true);
   };
 
   const hideModalHandler = () => {
-    setShowConnectModal(false);
+    setShowSettledNounModal(false);
   };
 
   // get the image of the most recently minted Noun from Twitter
   useEffect(() => {
-    if (showConnectModal && successfulSettle && localNounId > 0) {
+    if (showSettledNounModal && successfulFomoSettle && localNounId > 0) {
       setShareCopy(encodeURI("gm, I just minted this Noun for @nounsdao by playing FOMO Nouns! "));
       // wait for 750ms, then fetch image from twitter
       setTimeout(() => {
-        axios.get('/.netlify/functions/twitter', {params: {id: localNounId}})
-        .then( res => {
-          const data = res.data;
-          setMediaURL(data.mediaUrl);
-          setShowTwitter(mediaURL !== "");
-          //reload the twitter widgets
-          if (window) {
-            (window as any).twttr.widgets.load();
-          }
-        });
+        axios.get('/.netlify/functions/twitter', { params: { id: localNounId } })
+          .then(res => {
+            const data = res.data;
+            setMediaURL(data.mediaUrl);
+            setShowTwitter(mediaURL !== "");
+            //reload the twitter widgets
+            if (window) {
+              (window as any).twttr.widgets.load();
+            }
+          });
       }, 15000);
-      
+
       setConfetti(true);
     }
-  }, [showConnectModal, successfulSettle, showConfetti, localNounId, mediaURL]);
+  }, [showSettledNounModal, successfulFomoSettle, showConfetti, localNounId, mediaURL]);
 
   useEffect(() => {
     const getNounImg = () => {
@@ -79,39 +79,39 @@ const SettledAuctionModal: React.FC<{}> = props => {
       setLocalNounId(adjNounId);
       const seed = getNounSeedFromBlockHash(adjNounId, prevSettledBlockHash);
       const { parts, background } = getNounData(seed);
-  
+
       const svgBinary = buildSVG(parts, palette, background);
       setImg(btoa(svgBinary));
     }
 
     if (prevSettledBlockHash) {
       getNounImg();
-      attemptedSettleBlockHash === prevSettledBlockHash ? setSuccessfulSettle(true) : setSuccessfulSettle(false);
+      attemptedSettleBlockHash === prevSettledBlockHash ? setSuccessfulFomoSettle(true) : setSuccessfulFomoSettle(false);
       showModalHandler();
       dispatch(resetPrevSettledBlockHash());
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [attemptedSettleBlockHash, prevSettledBlockHash, nextNounId, dispatch]);
 
   const isTenthNoun = localNounId % 10 === 0;
-  const copy = successfulSettle ? `Hello, Noun ${isTenthNoun ? `${localNounId} & ${localNounId+1}`: localNounId} 👋` : `Someone else minted Noun ${isTenthNoun ? `${localNounId} & ${localNounId+1}`: localNounId}`;
-  const title = successfulSettle ? `We minted ${isTenthNoun ? 'some Nouns': 'a Noun'}!` : `We missed ${isTenthNoun ? 'them' : 'it'}!`;
+  const copy = successfulFomoSettle ? `Hello, Noun ${isTenthNoun ? `${localNounId} & ${localNounId + 1}` : localNounId} 👋` : `Someone else minted Noun ${isTenthNoun ? `${localNounId} & ${localNounId + 1}` : localNounId}`;
+  const title = successfulFomoSettle ? `We minted ${isTenthNoun ? 'some Nouns' : 'a Noun'}!` : `We missed ${isTenthNoun ? 'them' : 'it'}!`;
   const settledAuctionContent = (
     <>
-    <script async src="https://platform.twitter.com/widgets.js" charSet="utf-8"></script>
-    <Confetti active={showConfetti} config={confettiConfig}/>
-    <h3>{title}</h3>
-    <img src={`data:image/svg+xml;base64,${img}`} className={classes.NounImg} alt={`Minted Noun`}/>
-    <h3>{copy}</h3>
-    <p className={classes.Footer}>Come back and play again tomorrow!</p>
-    {showTwitter && 
-    <a className='twitter-share-button' href={`https://twitter.com/intent/tweet/?text=${shareCopy + mediaURL}`}>Tweet </a>}
+      <script async src="https://platform.twitter.com/widgets.js" charSet="utf-8"></script>
+      <Confetti active={showConfetti} config={confettiConfig} />
+      <h3>{title}</h3>
+      <img src={`data:image/svg+xml;base64,${img}`} className={classes.NounImg} alt={`Minted Noun`} />
+      <h3>{copy}</h3>
+      <p className={classes.Footer}>Come back and play again tomorrow!</p>
+      {showTwitter &&
+        <a className='twitter-share-button' href={`https://twitter.com/intent/tweet/?text=${shareCopy + mediaURL}`}>Tweet </a>}
     </>
-    );
+  );
 
   return (
     <div className={classes.ModalWrapper}>
-      {showConnectModal && <Modal content={settledAuctionContent} onDismiss={hideModalHandler}/>}
+      {showSettledNounModal && <Modal content={settledAuctionContent} onDismiss={hideModalHandler} />}
     </div>
   )
 };

--- a/packages/webapp/src/middleware/alchemyWebsocket.js
+++ b/packages/webapp/src/middleware/alchemyWebsocket.js
@@ -1,14 +1,11 @@
 import { default as globalConfig, PROVIDER_KEY } from '../config';
 
-import { contract as AuctionContract } from '../wrappers/nounsAuction';
-import { setAuctionEnd } from '../state/slices/auction';
 import { setEthereumConnected, setBlockAttr } from '../state/slices/block';
-import { setNextNounId } from '../state/slices/noun';
 import { resetVotes } from '../state/slices/vote';
 import { resetAuctionEnd } from '../state/slices/auction';
 import { default as config } from '../config';
 import { w3cwebsocket as W3CWebSocket } from 'websocket';
-import { checkForSettlement } from './ethersProvider';
+import { checkAuctionAndSettlement } from './ethersProvider';
 import { addPendingBidTx, addPendingSettleTx } from '../state/slices/mempool';
 import { isBidMethod, isSettleMethod } from '../utils/auctionMethods';
 
@@ -82,19 +79,10 @@ const alchemyWebsocketMiddleware = () => {
     } else {
       console.log(`Updating blocknumber ${blockNumber}`);
       latestObservedBlock = blockNumber;
-    }    
+    }
 
-    // Check if settlement has occurred
-    store.dispatch(checkForSettlement(logsBloom));
-
-    // Check the latest auction status
-    AuctionContract.auction().then((auction) => {
-      const nextNounId = parseInt(auction?.nounId) + 1;
-      const auctionEnd = auction?.endTime.toNumber();
-
-      store.dispatch(setNextNounId(nextNounId));
-      store.dispatch(setAuctionEnd(auctionEnd));
-    });
+    // Check latest auction state and if settlement has occurred
+    store.dispatch(checkAuctionAndSettlement({ "logsBloom": logsBloom, "blockNumber": blockNumber }));
 
     // Update the Redux block information
     store.dispatch(setBlockAttr({'blocknumber': blockNumber, 'blockhash': blockHash}));

--- a/packages/webapp/src/middleware/ethersProvider.js
+++ b/packages/webapp/src/middleware/ethersProvider.js
@@ -38,7 +38,7 @@ const ethersProviderMiddleware = () => {
   const checkSettlementTx = async (store, blockNumber) => {
     if (!blockNumber) return;
 
-    let blockWithTxs = await RPCProvider.getBlockWithTransactions(blockNumber);
+    const blockWithTxs = await RPCProvider.getBlockWithTransactions(blockNumber);
 
     const settleTx = blockWithTxs.transactions.find(tx => possibleSettleContracts.includes(tx.to));
 

--- a/packages/webapp/src/middleware/ethersProvider.js
+++ b/packages/webapp/src/middleware/ethersProvider.js
@@ -1,49 +1,99 @@
-import { default as config, provider as RPCProvider} from '../config';
+import { default as config, provider as RPCProvider } from '../config';
 
 import { setPrevSettledBlockHash } from '../state/slices/settlement';
 import { isTopicInBloom, isContractAddressInBloom } from 'ethereum-bloom-filters';
+import { contract as AuctionContract } from '../wrappers/nounsAuction';
+import { setAuctionEnd } from '../state/slices/auction';
+import { setNextNounId } from '../state/slices/noun';
+import { isSettleMethod as isAuctionSettleMethod } from '../utils/auctionMethods';
+import { isSettleMethod as isFomoSettleMethod } from '../utils/fomoMethods';
 
 // Define the Actions Intercepted by the Middleware
-const checkForSettlement = (payload) => ({type: 'ethereumProvider/checkSettlement', payload});
+const checkAuctionAndSettlement = (payload) => ({ type: 'ethereumProvider/checkAuctionAndSettlement', payload });
 
 const settlementTopic = '0xc9f72b276a388619c6d185d146697036241880c36654b1a3ffdad07c24038d99';
 const auctionAddress = config.auctionProxyAddress;
-const settledFilter = {address: auctionAddress, topics: [settlementTopic]};
+const fomoAddress = config.fomoSettlerAddress;
 
+const possibleSettleContracts = [auctionAddress, fomoAddress];
 
 // Define the Middleware
 const ethersProviderMiddleware = () => {
+  let latestActiveNounId = undefined;
 
-  // Define the Handler Methods
+  // Bloom checks could give false positives
   const settlementInBloom = (logsBloom) => {
     try {
       return isTopicInBloom(logsBloom, settlementTopic) &&
-            isContractAddressInBloom(logsBloom, auctionAddress);
+        isContractAddressInBloom(logsBloom, auctionAddress);
     } catch {
       return false;
     }
   }
 
-  const confirmSettlement = (store) => {
-    RPCProvider.getLogs(settledFilter)
-      .then((logs) => logs[0]?.blockNumber)
-      .then(async (blockNumber) => {
-        if (!blockNumber) return;
-        let block = await RPCProvider.getBlock(blockNumber - 1);
-        store.dispatch(setPrevSettledBlockHash(block.hash));
-      })
-      .catch(() => {
-        console.log('Error parsing settlement logs');
-      });
+  const settleMethod = (input) => {
+    return isFomoSettleMethod(input) || isAuctionSettleMethod(input);
+  }
+
+  const checkSettlementTx = async (store, blockNumber) => {
+    if (!blockNumber) return;
+
+    let blockWithTxs = await RPCProvider.getBlockWithTransactions(blockNumber);
+
+    const settleTx = blockWithTxs.transactions.find(tx => possibleSettleContracts.includes(tx.to));
+
+    if (settleTx && settleMethod(settleTx.data)) {
+      const receipt = await settleTx.wait();
+
+      if (receipt.status === 1) {
+        confirmSettlement(store, blockNumber);
+      } else {
+        console.log("Reverted tx")
+      }
+    } else {
+      console.log("Couldn't find tx with auction settle call")
+    }
+  }
+
+  const confirmSettlement = async (store, blockNumber) => {
+    if (!blockNumber) return;
+    const block = await RPCProvider.getBlock(blockNumber - 1);
+    store.dispatch(setPrevSettledBlockHash(block.hash));
+  }
+
+  const checkAuctionAndSettlement = async (store, logsBloom, blockNumber) => {
+    // Check the latest auction status
+    const auction = await AuctionContract.auction();
+
+    const nounId = parseInt(auction?.nounId);
+    const auctionEnd = auction?.endTime.toNumber();
+
+    if (latestActiveNounId !== nounId && settlementInBloom(logsBloom)) {
+      if (latestActiveNounId === undefined) {
+        // Go more safe route by checking for settle tx
+        // in a block and not base assumptions only on bloom
+        // filters as they may give false positives 
+        checkSettlementTx(store, blockNumber);
+      } else {
+        // Else if noun id has increased it means tx
+        // that modified auction state run successefuly
+        // and additional checks can be skipped
+        confirmSettlement(store, blockNumber);
+      }
+    }
+
+    latestActiveNounId = nounId
+
+    store.dispatch(setNextNounId(nounId + 1));
+    store.dispatch(setAuctionEnd(auctionEnd));
   }
 
   // Define the Middleware
   return store => next => action => {
-    if (action.type === 'ethereumProvider/checkSettlement') {
-      const logsBloom = action.payload;
-      if (settlementInBloom(logsBloom)) {
-        confirmSettlement(store);
-      }
+    if (action.type === 'ethereumProvider/checkAuctionAndSettlement') {
+      const { logsBloom, blockNumber } = action.payload;
+
+      checkAuctionAndSettlement(store, logsBloom, blockNumber);
     } else {
       return next(action);
     }
@@ -52,4 +102,4 @@ const ethersProviderMiddleware = () => {
 
 
 export default ethersProviderMiddleware();
-export { checkForSettlement };
+export { checkAuctionAndSettlement };

--- a/packages/webapp/src/utils/fomoMethods.ts
+++ b/packages/webapp/src/utils/fomoMethods.ts
@@ -1,0 +1,12 @@
+import { contract as FomoContract } from '../wrappers/fomoSettlement';
+
+const settleMethods = ['settleAuctionWithRefund', 'settleAuction']
+
+export const isSettleMethod = (input: string) => {
+    try {
+        const decodedInput = FomoContract.interface.parseTransaction({ data: input })
+        return settleMethods.includes(decodedInput.name);
+    } catch {
+        return false;
+    }
+};


### PR DESCRIPTION
This PR fixes several serious issues:

### 1. The incorrect noun is shown after auction settle (race condition related)

The errors happened due to the sometimes slow speed of loading the latest Auction data from the chain. As settlement checks and Auction data updates happened in a "parallel" manner, sometimes a "settled" modal would appear before the Auction data finish loading, leading to the modal noun being derived with an incorrect noun id.
The fix is done by always awaiting for Auction info to be loaded before the settlement is checked. This way, `nounId` is always correct when the "settled" modal appears.

### 2. Settle modal appears even when settle didn't happen (bloom filters weakness related)

Bloom filters may give false positives. For example, in cases when settle tx was sent but was reverted. Check data still appear in bloom, giving a false positive result.

To account for this, several new checks were added:

1. Check of noun id change through Fomo gameplay. If we load and save noun id `234` and with a new check, it changes to `235` and bloom check is positive, we can be sure that settle happened.
2. In case settle happens on the site open, and we still don't have prerecorded `nounId`, we additionally load all tx from the block and check for successful settle transaction. This ensures we don't rely just on bloom data to draw conclusions in case of other data shortages.

These changes "slow down" the modal appearance a bit, but the work has been done to ensure maximum possible speed while covering all possible error cases. In the end, the speed change is hardly noticeable in regular usage. Meanwhile, detection became much more bulletproof.

Also, this PR fixes settled noun modal vertical positioning and introduce some variable names refactor.

## Testing

All test code is added to `middleware/ethersProvider.js`.

Tests for when the user just opens the website, and we get some settle positives:

### 1. Just bloom that will give a positive result

To test for correct block transactions checks, we may use bloom which gives a false positive:

```js
// Define the Middleware
  return store => next => action => {
    if (action.type === 'ethereumProvider/checkAuctionAndSettlement') {
      const { logsBloom, blockNumber } = action.payload;

      const fakeBloom = '0x9ffaffffbffffffbdffbf7ffbffffff7d3fffbffff7fdfb8fffffe7ffff7ffec7f75f97ffffbfbdfd7bbf9ffdffaf3dcbf79effbbf9fbfdffeffffffffffffff57ffe7effaeff5fff9effeffebffef7ffffffebfeffdffcbeff7bffffdfffedffffffd7df7ffffbfefffffff3df9fdfbfffffffeeffff7ffff7ffdf7f1bffffdffbedffffb9ffbfffffff75fffee7fff77fd7bfffff7fdffff7ffbffeff3ffbffffdffbbffdfff7b7fffffffbfffffbffff7bfffbff7dfff7ffffe7fffbfafeff5ffffff7fbfe5fffff9fffdddf7ffefbbffffffbd6bfffffaffff7fdaefbfefbaffffffffffff9ffffdfd7fddff5bfbfffbbbfff5fbfffdfeebfbfff7ffbf67'

      // checkAuctionAndSettlement(store, logsBloom, blockNumber);
      checkAuctionAndSettlement(store, fakeBloom, blockNumber);
    } else {
      return next(action);
    }
  };
```
**Result:** we should see "Couldn't find tx with auction settle call" printed to the console. No modal. (Bloom - `true`, tx in block - `false`).

### 2. Bloom that will give a positive result and block with settle tx

To make the first case positive, we also check block with successful settle tx:

```js
const checkSettlementTx = async (store, blockNumber) => {
    if (!blockNumber) return;

    // let blockWithTxs = await RPCProvider.getBlockWithTransactions(blockNumber);
    let blockWithTxs = await RPCProvider.getBlockWithTransactions(15647129);

    ...
}
```
**Result:** we should see a modal with the "settled" noun. It may take 2-3 sec to do all the checks. (Bloom - `true`, tx in block - `true`)

Test for the usual game flow:

### 3. Positive Bloom and noun `id` change

This is the usual confirmation case when settle happened when user was actively playing Fomo.

1. Remove the predefined block number code from `test case 2`
2. Keep the fake bloom code from `test case 1`
3. Add this code to simulate noun `id` increase:
```js
const checkAuctionAndSettlement = async (store, logsBloom, blockNumber) => {
    // Check the latest auction status
    const auction = await AuctionContract.auction();

    // const nounId = parseInt(auction?.nounId);
    const nounId = latestActiveNounId === undefined ? parseInt(auction?.nounId) : parseInt(auction?.nounId) + 1;
    
    ...
}
```

**Result:** we should see a modal with the "settled" noun. Wait for the second block update. (Bloom - `true`, id change - `true`)

We can also play with different `true`/`false` cases for different data, but in the end, we don't rely on just bloom logs checks, and the modal should appear only after we have confirmation from the block transactions or Auction data checks. 