### PR TITLE
Require reCaptcha for voting 

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -5,9 +5,12 @@
 This has the code and deployment infrastructure for the FOMO Nouns backend. This backend allows users to connect via websocket, votes to be submitted and stored in a DynamoDB table, and when a quorum of votes likes a Noun, launches settlement on the FOMO Nouns contract.
 
 Dependencies:
- - AWS Account with Appropriate IAM Accesses
- - AWS CLI
- - Alchemy API Key & Ethereum Account with ETH
+
+- AWS Account with Appropriate IAM Accesses
+- AWS CLI
+- Alchemy API Key & Ethereum Account with ETH
+- Google Cloud account with ReCaptcha v3 Enterprise Enabled
+- Score based ReCaptcha API Key
 
 ## Setup
 
@@ -19,12 +22,29 @@ First, install the AWS CLI ([instructions](https://docs.aws.amazon.com/cli/lates
 
 ### 2. Store private keys in AWS Secrets Manager
 
-Run `key-management.sh` script to store your Alchemy API key and Ethereum Executor Account private key in AWS Secrets Manager:
+Run `key-management.sh` script to store:
+
+1. Alchemy API key
+2. Ethereum Executor Account private key
+3. Google Cloud Project API key
+4. Google Cloud Project Id
+5. ReCaptcha key (Score based)
+6. ReCaptcha Action specified in ReCaptcha call
+7. ReCaptcha threshold (0.0-1.0)*
+
+in AWS Secrets Manager:
 
 ```
 ./key-management.sh --set --alchemy "<YOUR_PRIVATE_KEY>"
 ./key-management.sh --set --executor "0x<YOUR_PRIVATE_KEY>"
+./key-management.sh --set --google-api-key "<YOUR_API_KEY>"
+./key-management.sh --set --google-project-id "<YOUR_PROJECT_ID>"
+./key-management.sh --set --recaptcha-key "<YOUR_RECAPTCHA_KEY>"
+./key-management.sh --set --recaptcha-action "<YOUR_RECAPTCHA_ACTION>"
+./key-management.sh --set --recaptcha-threshold "<YOUR_RECAPTCHA_THRESHOLD>"
 ```
+
+(*) This is used to determine when to restrict access to backend. In ReCaptcha score 0.0 is highest risk, 1.0 is lowest risk. Setting threshold to 0.0 will allow bots to send votes, setting to 1.0 will allow only most reCaptcha trusted and legitimate "users" to be able to send votes. Setting to 1.0 may limit other actual (and legitimate) users from sending votes ([learn more](https://cloud.google.com/recaptcha-enterprise/docs/interpret-assessment?authuser=6#interpret_scores)). Set this value according to analytics.
 
 ### 3. Build and Deploy
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -44,6 +44,12 @@ in AWS Secrets Manager:
 ./key-management.sh --set --recaptcha-threshold "<YOUR_RECAPTCHA_THRESHOLD>"
 ```
 
+If you deploy to non standard AWS region (us-east-2), you may specify region after `key` value:
+
+```
+./key-management.sh --set --alchemy "<YOUR_PRIVATE_KEY>" <YOUR_AWS_REGION>
+```
+
 (*) This is used to determine when to restrict access to backend. In ReCaptcha score 0.0 is highest risk, 1.0 is lowest risk. Setting threshold to 0.0 will allow bots to send votes, setting to 1.0 will allow only most reCaptcha trusted and legitimate "users" to be able to send votes. Setting to 1.0 may limit other actual (and legitimate) users from sending votes ([learn more](https://cloud.google.com/recaptcha-enterprise/docs/interpret-assessment?authuser=6#interpret_scores)). Set this value according to analytics.
 
 ### 3. Build and Deploy

--- a/packages/backend/axios-layer/package.json
+++ b/packages/backend/axios-layer/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "axios-layer",
+    "version": "1.0.0",
+    "description": "Layer for axios dependencies",
+    "dependencies": {
+        "axios": "^1.1.3"
+    }
+}

--- a/packages/backend/checkcaptcha/app.js
+++ b/packages/backend/checkcaptcha/app.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Event Example:
+ *   {"action": "checkcaptcha", "token": "..."}
+ * 
+ */
+
+const AWS = require('aws-sdk');
+
+const { AWS_REGION, SOCKET_TABLE_NAME } = process.env;
+
+const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10', region: AWS_REGION });
+const smc = new AWS.SecretsManager({ region: AWS_REGION });
+
+const { getReCaptchaKeys } = require('./utils/getReCaptchaKeys.js');
+
+
+async function updateStatus(connectionId, captchaPassed) {
+  const updateParams = {
+    TableName: SOCKET_TABLE_NAME,
+    Key: { 'connectionId': connectionId },
+    ExpressionAttributeValues: { ':cp': captchaPassed },
+    UpdateExpression: 'set captchaPassed = :cp'
+  };
+
+  try {
+    await ddb.update(updateParams).promise();
+  } catch (err) {
+    throw err;
+  }
+}
+
+
+exports.handler = async event => {
+  const connectionId = event.requestContext.connectionId;
+  const body = JSON.parse(event.body);
+  const token = body.token;
+
+  const {
+    googleApiKey,
+    googleProjectId,
+    reCaptchaKey,
+    reCaptchaAction,
+    reCaptchaThreshold
+  } = await getReCaptchaKeys(smc);
+
+  //TODO: the fetch
+
+  const captchaPassed = true;
+
+  try {
+    await updateStatus(connectionId, captchaPassed);
+  } catch (err) {
+    return { statusCode: 500, body: 'Error updating captcha status in DB.', message: err.stack };
+  }
+
+  return { statusCode: 200, body: 'Captcha status updated.' };
+};

--- a/packages/backend/checkcaptcha/package.json
+++ b/packages/backend/checkcaptcha/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "checkcaptcha",
+  "version": "1.0.0",
+  "description": "Check user's captcha token and save status to db",
+  "main": "src/app.js",
+  "author": "ng",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "aws-sdk": "^2.739.0"
+  }
+}

--- a/packages/backend/checkcaptcha/utils/getReCaptchaKeys.js
+++ b/packages/backend/checkcaptcha/utils/getReCaptchaKeys.js
@@ -1,0 +1,49 @@
+/**
+ * Retrieve the private keys needed for Ethereums settlement and interactions
+ * 
+ * @param {SecretsManager} secretsManager Instance of AWS SDK Secrets Manager
+ * @returns {String, String} Returns Google Project API Key, Google Cloud project ID, ReCaptcha v3 Enterprise key, ReCaptcha v3 Action and ReCaptcha Score Threshold
+ */
+async function getReCaptchaKeys(secretsManager) {
+  let googleApiKey, googleProjectId, reCaptchaKey, reCaptchaAction, scoreThreshold;
+
+  let googleApiKeyPromise = secretsManager.getSecretValue({ SecretId: 'nouns/GoogleApiKey' }, (_, data) => {
+    googleApiKey = data.SecretString;
+  }).promise();
+
+  let googleProjectIdPromise = secretsManager.getSecretValue({ SecretId: 'nouns/GoogleProjectId' }, (_, data) => {
+    googleProjectId = data.SecretString;
+  }).promise();
+
+  let reCaptchaKeyPromise = secretsManager.getSecretValue({ SecretId: 'nouns/ReCaptchaKey' }, (_, data) => {
+    reCaptchaKey = data.SecretString;
+  }).promise();
+
+  let reCaptchaActionPromise = secretsManager.getSecretValue({ SecretId: 'nouns/ReCaptchaAction' }, (_, data) => {
+    reCaptchaAction = data.SecretString;
+  }).promise();
+
+  let scoreThresholdPromise = secretsManager.getSecretValue({ SecretId: 'nouns/ReCaptchaThreshold' }, (_, data) => {
+    scoreThreshold = data.SecretString;
+  }).promise();
+
+  await Promise.all([
+    googleApiKeyPromise,
+    googleProjectIdPromise,
+    reCaptchaKeyPromise,
+    reCaptchaActionPromise,
+    scoreThresholdPromise
+  ]); // Pull in parallel for speed
+
+  return {
+    googleApiKey: googleApiKey,
+    googleProjectId: googleProjectId,
+    reCaptchaKey: reCaptchaKey,
+    reCaptchaAction: reCaptchaAction,
+    reCaptchaThreshold: scoreThreshold
+  };
+}
+
+module.exports = {
+  getReCaptchaKeys
+};

--- a/packages/backend/key-management.sh
+++ b/packages/backend/key-management.sh
@@ -9,6 +9,21 @@ if [[ "$2" == "--alchemy" ]]; then
 elif [[ "$2" == "--executor" ]]; then
   NAME="nouns/ExecutorPrivateKey"
   DESCRIPTION="Ethereum private key with Executor rights to the FOMO Nouns Contract"
+elif [[ "$2" == "--google-api-key" ]]; then
+  NAME="nouns/GoogleApiKey"
+  DESCRIPTION="ReCaptcha: API key associated with the Google Cloud project"
+elif [[ "$2" == "--google-project-id" ]]; then
+  NAME="nouns/GoogleProjectId"
+  DESCRIPTION="ReCaptcha: Google Cloud project ID"
+elif [[ "$2" == "--recaptcha-key" ]]; then
+  NAME="nouns/ReCaptchaKey"
+  DESCRIPTION="ReCAPTCHA key associated with the site/app"
+elif [[ "$2" == "--recaptcha-action" ]]; then
+  NAME="nouns/ReCaptchaAction"
+  DESCRIPTION="ReCAPTCHA: the user-initiated action specified in ReCaptcha call"
+elif [[ "$2" == "--recaptcha-threshold" ]]; then
+  NAME="nouns/ReCaptchaThreshold"
+  DESCRIPTION="ReCAPTCHA: threshold to determine when to restrict access to backend"
 else
   ACTION=""
 fi

--- a/packages/backend/key-management.sh
+++ b/packages/backend/key-management.sh
@@ -2,6 +2,7 @@
 
 ACTION="$1"
 SECRET="$3"
+REGION="$4"
 
 if [[ "$2" == "--alchemy" ]]; then
   NAME="nouns/AlchemyKey"
@@ -28,12 +29,16 @@ else
   ACTION=""
 fi
 
+if [ -z "$REGION" ]; then 
+  REGION="us-east-2"
+fi
+
 if [[ "$ACTION" == "--set" ]]; then
-  aws secretsmanager create-secret --name "$NAME" --description "$DESCRIPTION" --secret-string "$SECRET"
+  aws secretsmanager create-secret --name "$NAME" --description "$DESCRIPTION" --secret-string "$SECRET" --region "$REGION"
 elif [[ "$ACTION" == "--update" ]]; then
-  aws secretsmanager update-secret --secret-id "$NAME" --secret-string "$SECRET"
+  aws secretsmanager update-secret --secret-id "$NAME" --secret-string "$SECRET" --region "$REGION"
 elif [[ "$ACTION" == "--get" ]]; then
-  aws secretsmanager describe-secret --secret-id "$NAME"
+  aws secretsmanager describe-secret --secret-id "$NAME" --region "$REGION"
 else
   echo '''The script can be run with the following commands:
     ./key-management.sh --set --executor/--alchemy <private_key>

--- a/packages/backend/onconnect/app.js
+++ b/packages/backend/onconnect/app.js
@@ -12,7 +12,8 @@ exports.handler = async event => {
   const putParams = {
     TableName: SOCKET_TABLE_NAME,
     Item: {
-      connectionId: event.requestContext.connectionId
+      connectionId: event.requestContext.connectionId,
+      captchaPassed: null
     }
   };
 

--- a/packages/backend/template.yaml
+++ b/packages/backend/template.yaml
@@ -125,6 +125,26 @@ Resources:
       IntegrationUri: 
         Fn::Sub:
             arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ChangeStatusFunction.Arn}/invocations
+  CheckCaptchaRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref NounsWebSocket
+      RouteKey: checkcaptcha
+      AuthorizationType: NONE
+      OperationName: CheckCaptchaRoute
+      Target: !Join
+        - '/'
+        - - 'integrations'
+          - !Ref CheckCaptchaInteg
+  CheckCaptchaInteg:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref NounsWebSocket
+      Description: CheckCaptcha Integration
+      IntegrationType: AWS_PROXY
+      IntegrationUri: 
+        Fn::Sub:
+            arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CCheckCaptchaFunction.Arn}/invocations
   Deployment:
     Type: AWS::ApiGatewayV2::Deployment
     DependsOn:
@@ -132,6 +152,7 @@ Resources:
     - SendRoute
     - DisconnectRoute
     - ChangeStatusRoute
+    - CheckCaptchaRoute
     Properties:
       ApiId: !Ref NounsWebSocket
   Stage:
@@ -248,6 +269,54 @@ Resources:
       Principal: apigateway.amazonaws.com
 
   #----------------------------------------#
+  # Lambda: CheckCaptcha from Websocket
+  #----------------------------------------#
+  AxiosDepLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: axios-dependency
+      Description: Axios dependency
+      ContentUri: axios-layer/
+      CompatibleRuntimes:
+        - nodejs14.x
+      RetentionPolicy: Retain
+    Metadata:
+      BuildMethod: nodejs14.x
+  CheckCaptchaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: checkcaptcha/
+      Handler: app.handler
+      MemorySize: 256
+      Runtime: nodejs14.x
+      Layers:
+        - !Ref AxiosDepLayer
+      Environment:
+        Variables:
+          SOCKET_TABLE_NAME: !Ref SocketTableName
+      Policies:
+      - DynamoDBCrudPolicy:
+          TableName: !Ref SocketTableName
+      - Statement:
+        - Effect: Allow
+          Action:
+          - 'secretsmanager:GetSecretValue'
+          Resource:
+          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:nouns/GoogleApiKey-*'
+          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:nouns/GoogleProjectId-*'
+          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:nouns/ReCaptchaKey-*'
+          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:nouns/ReCaptchaAction-*'
+          - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:nouns/ReCaptchaThreshold-*'
+  CheckCaptchaPermission:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+      - NounsWebSocket
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref ChangeStatusFunction
+      Principal: apigateway.amazonaws.com
+
+  #----------------------------------------#
   # Lambda: SendVote Websocket Handler
   #----------------------------------------#
   SendVoteFunction:
@@ -349,6 +418,10 @@ Outputs:
   ChangeStatusFunctionArn:
     Description: "ChangeStatus function ARN"
     Value: !GetAtt ChangeStatusFunction.Arn
+
+  CheckCaptchaFunctionArn:
+    Description: "CheckCaptcha function ARN"
+    Value: !GetAtt CheckCaptchaFunction.Arn
 
   SendVoteFunctionArn:
     Description: "SendVote function ARN"

--- a/packages/backend/template.yaml
+++ b/packages/backend/template.yaml
@@ -144,7 +144,7 @@ Resources:
       IntegrationType: AWS_PROXY
       IntegrationUri: 
         Fn::Sub:
-            arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CCheckCaptchaFunction.Arn}/invocations
+            arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CheckCaptchaFunction.Arn}/invocations
   Deployment:
     Type: AWS::ApiGatewayV2::Deployment
     DependsOn:

--- a/packages/backend/template.yaml
+++ b/packages/backend/template.yaml
@@ -313,7 +313,7 @@ Resources:
       - NounsWebSocket
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref ChangeStatusFunction
+      FunctionName: !Ref CheckCaptchaFunction
       Principal: apigateway.amazonaws.com
 
   #----------------------------------------#

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -35,6 +35,7 @@
     "react-bootstrap": "^2.0.0",
     "react-dom": "^17.0.2",
     "react-dom-confetti": "^0.2.0",
+    "react-google-recaptcha-v3": "^1.10.0",
     "react-hot-toast": "^2.3.0",
     "react-redux": "^7.2.5",
     "react-router-dom": "^5.3.0",

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -73,16 +73,17 @@ function App() {
 
   const reCaptchaVerify = useCallback(async () => {
     if (!executeRecaptcha) return;
-    if (!voteWSConnected) return;
 
     const token = await executeRecaptcha(RECAPTCHA_ACTION_NAME);
     dispatch(sendCaptchaToken({ "token": token }));
-  }, [executeRecaptcha, dispatch, voteWSConnected]);
+  }, [executeRecaptcha, dispatch]);
 
-  // Get reCaptcha user token and open vote socket
+  // Get reCaptcha user token
   useEffect(() => {
-    reCaptchaVerify();
-  }, [reCaptchaVerify]);
+    if (voteWSConnected) {
+      reCaptchaVerify();
+    }
+  }, [reCaptchaVerify, voteWSConnected]);
 
   return (
     <div className={`${classes.App} ${isCoolBackground ? classes.bgGrey : classes.bgBeige}`}>

--- a/packages/webapp/src/components/VoteBar/index.tsx
+++ b/packages/webapp/src/components/VoteBar/index.tsx
@@ -1,33 +1,53 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import VoteButton from '../VoteButton';
 import { VOTE_OPTIONS, setVotingBlockHash } from '../../state/slices/vote';
 import classes from './VoteBar.module.css';
 import { useAppDispatch, useAppSelector } from '../../hooks';
-import { openVoteSocket } from '../../middleware/voteWebsocket';
+import { openVoteSocket, sendCaptchaToken } from '../../middleware/voteWebsocket';
 import { openEthereumSocket } from '../../middleware/alchemyWebsocket';
+import { RECAPTCHA_ACTION_NAME } from "../../config";
+import { useGoogleReCaptcha } from "react-google-recaptcha-v3";
 
 
-const VoteBar:React.FC<{}> = (props) => {
+const VoteBar: React.FC<{}> = (props) => {
   const dispatch = useAppDispatch();
+  const { executeRecaptcha } = useGoogleReCaptcha();
   const activeAuction = useAppSelector(state => state.auction.activeAuction);
   const voteSocketConnected = useAppSelector(state => state.vote.connected);
   const ethereumSocketConnected = useAppSelector(state => state.block.connected);
   const votingActive = useAppSelector(state => state.vote.votingActive);
   const blockhash = useAppSelector(state => state.block.blockHash);
 
+  const [connectRequested, setConnectRequested] = useState(false);
+
   // Approves a specific blockhash for voting after a period of time. This prevents the user from voting on a Noun by mistake as a new block is received.
-  useEffect( () => {
+  useEffect(() => {
     const timerId = setTimeout(dispatch, 500, setVotingBlockHash(blockhash));
     return () => clearTimeout(timerId);
   }, [blockhash, dispatch])
 
+  const reCaptchaVerify = useCallback(async () => {
+    if (!executeRecaptcha) return;
+
+    const token = await executeRecaptcha(RECAPTCHA_ACTION_NAME);
+    dispatch(sendCaptchaToken({ "token": token }));
+    setConnectRequested(false);
+  }, [executeRecaptcha, dispatch]);
+
+  useEffect(() => {
+    if (connectRequested && voteSocketConnected) {
+      reCaptchaVerify();
+    }
+  }, [reCaptchaVerify, voteSocketConnected, connectRequested]);
+
   const openSocket = () => {
     if (!voteSocketConnected) {
       dispatch(openVoteSocket());
+      setConnectRequested(true);
     }
     if (!ethereumSocketConnected) {
       dispatch(openEthereumSocket());
-    }    
+    }
   }
 
   const voteOpts = (neutralOption: boolean) => (
@@ -46,14 +66,14 @@ const VoteBar:React.FC<{}> = (props) => {
     <span className={classes.reconnect} onClick={openSocket}>Click to Enable Voting</span>
   )
 
-  return(
+  return (
     <div className={`
       ${(!votingActive || activeAuction === undefined) ? classes.VoteBarOverlay : ''}
       ${classes.VoteBar}`}
     >
-      { (voteSocketConnected && ethereumSocketConnected) ? voteOpts(false)
+      {(voteSocketConnected && ethereumSocketConnected) ? voteOpts(false)
         : !ethereumSocketConnected ? reconnectOpt
-        : voteReconnectOpt }
+          : voteReconnectOpt}
     </div>
   );
 }

--- a/packages/webapp/src/config.ts
+++ b/packages/webapp/src/config.ts
@@ -10,6 +10,8 @@ export const PROVIDER_NAME = process.env.REACT_APP_PROVIDER_NAME!;
 export const FOMO_WEBSOCKET = process.env.REACT_APP_WEB_SOCKET!;
 export const PROVIDER_KEY = process.env.REACT_APP_PROVIDER_KEY!;
 export const ETHERSCAN_API_KEY = process.env.REACT_APP_ETHERSCAN_API_KEY!;
+export const RECAPTCHA_KEY = process.env.REACT_APP_RECAPTCHA_KEY!;
+export const RECAPTCHA_ACTION_NAME = process.env.REACT_APP_RECAPTCHA_ACTION_NAME!;
 /*--------------------------*/
 
 // TODO: Clean this up

--- a/packages/webapp/src/index.tsx
+++ b/packages/webapp/src/index.tsx
@@ -21,10 +21,11 @@ import { routerMiddleware } from 'connected-react-router';
 import { Provider } from 'react-redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import dotenv from 'dotenv';
-import { default as globalConfig } from './config';
+import { default as globalConfig, RECAPTCHA_KEY } from './config';
 import voteWebsocket from './middleware/voteWebsocket';
 import ethersProviderMiddleware from './middleware/ethersProvider';
 import alchemyWebsocketMiddleware from './middleware/alchemyWebsocket';
+import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
 
 
 dotenv.config();
@@ -78,8 +79,10 @@ ReactDOM.render(
       <Web3ReactProvider getLibrary={
         (provider, connector) => new Web3Provider(provider)
       }>
-        <DAppProvider config={config}> 
-          <App />
+        <DAppProvider config={config}>
+          <GoogleReCaptchaProvider reCaptchaKey={RECAPTCHA_KEY}>
+            <App />
+          </GoogleReCaptchaProvider>
         </DAppProvider>
       </Web3ReactProvider>
     </React.StrictMode>

--- a/packages/webapp/yarn.lock
+++ b/packages/webapp/yarn.lock
@@ -18399,6 +18399,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-google-recaptcha-v3@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "react-google-recaptcha-v3@npm:1.10.0"
+  dependencies:
+    hoist-non-react-statics: ^3.3.2
+  peerDependencies:
+    react: ^17.0 || ^18.0
+    react-dom: ^17.0 || ^18.0
+  checksum: 43b19eba4e4ebf96f6d9256fcb5a93aabe69878ce9fe4a6c73a3175d0ec9990abb39302c361ca99d7f20b2401353dce69236f299e64ee23a61fc71633b9107f3
+  languageName: node
+  linkType: hard
+
 "react-hot-toast@npm:^2.3.0":
   version: 2.3.0
   resolution: "react-hot-toast@npm:2.3.0"
@@ -22429,6 +22441,7 @@ __metadata:
     react-bootstrap: ^2.0.0
     react-dom: ^17.0.2
     react-dom-confetti: ^0.2.0
+    react-google-recaptcha-v3: ^1.10.0
     react-hot-toast: ^2.3.0
     react-redux: ^7.2.5
     react-router-dom: ^5.3.0


### PR DESCRIPTION
This PR introduces a requirement for FE to pass and send a reCaptcha test to be able to send votes.

### Env variables
It requires the addition of .env variables:

Front-End:
```
REACT_APP_RECAPTCHA_KEY
REACT_APP_RECAPTCHA_ACTION_NAME
```

Back-End:
```
Google Cloud Project API key
Google Cloud Project Id
ReCaptcha key
ReCaptcha Action
ReCaptcha threshold
```
Back-end set-up instructions are in `packages/backend/README`.

## Testing
If the front-end doesn't send a reCaptcha token, it should be prohibited from voting. This can be emulated by commenting out send in `webapp/src/middleware/voteWebsocket.js`:
```
const handleCaptchaToken = (msg) => {
    try {
      const { token } = msg;
      const tokenMsg = { "action": "checkcaptcha", "token": token };
      // socket.send(JSON.stringify(tokenMsg));
    } catch (e) {
      console.error('Websocket "checkcaptcha" message ill-formed');
      console.log(e);
    }
  }
```