### PR TITLE
Back-end: Allow voting only after some time pass since connecting to WS

### DIFF
--- a/packages/backend/sendvote/app.js
+++ b/packages/backend/sendvote/app.js
@@ -140,13 +140,14 @@ async function callSettlement(nounId, blockhash) {
   }
 }
 
+
 /**
  * Check if 8 seconds have passed since the user connected to backend
  * 
  * @param {number} connectedAt timestamp when the user connected to backend WS
  */
 function enoughTimePassed(connectedAt) {
-  return Date.now() - 8000 - connectedAt >= 0
+  return Date.now() - 8000 - connectedAt >= 0;
 }
 
 
@@ -167,7 +168,7 @@ exports.handler = async event => {
   const dbKey = `${nounId}||${blockhash}`;
   const endpoint = `${context.domainName}/${context.stage}`;
 
-  const timeBufferPassed = enoughTimePassed(context.connectedAt)
+  const timeBufferPassed = enoughTimePassed(context.connectedAt);
 
   if (!timeBufferPassed) {
     return { statusCode: 403, body: 'Voting restricted: not enough time have passed since connecting' };


### PR DESCRIPTION
Setting the time buffer will prevent bots from sending votes right after they connect to the back-end. It'll make it more complicated to attack Fomo.

## Testing
Change code in `VoteButton` component to allow sending votes when auction is running:
```tsx
...
const changeVote = () => {
  // if (currentVote || !wsConnected) return;

  dispatch(setCurrentVote(voteType));
  dispatch(sendVote({ "nounId": nextNounId, "blockhash": blockHash, "vote": voteType }));
}

// const disabled = voteNotSelected || (!votingActive || activeAuction) || blockHash !== votingBlockHash
const disabled = false
...
```
- You should be able to send votes only after 8 seconds pass since connecting to back-end.